### PR TITLE
[server/log] simplify the log messages before filtering

### DIFF
--- a/src/server/logging/LogFormat.js
+++ b/src/server/logging/LogFormat.js
@@ -6,7 +6,7 @@ let ansicolors = require('ansicolors');
 let stringify = require('json-stringify-safe');
 let querystring = require('querystring');
 let inspect = require('util').inspect;
-let applyFilterToKey = require('./applyFilterToKey');
+let applyFiltersToKeys = require('./applyFilterToKey').applyFiltersToKeys;
 
 function serializeError(err) {
   return {
@@ -36,12 +36,8 @@ module.exports = class TransformObjStream extends Stream.Transform {
   }
 
   filter(data) {
-    if (this.config.filter) {
-      _.each(this.config.filter, (action, key) => {
-        applyFilterToKey(data, key, action);
-      });
-    }
-    return data;
+    if (!this.config.filter) return data;
+    return applyFiltersToKeys(data, this.config.filter);
   }
 
   _transform(event, enc, next) {

--- a/src/server/logging/__tests__/applyFilterToKey.js
+++ b/src/server/logging/__tests__/applyFilterToKey.js
@@ -1,4 +1,5 @@
 var applyFilterToKey = require('../applyFilterToKey');
+var applyFiltersToKeys = applyFilterToKey.applyFiltersToKeys;
 var expect = require('expect.js');
 
 function fixture() {
@@ -15,7 +16,7 @@ describe('applyFilterToKey(obj, key, action)', function () {
 
   it('should remove a key from an object recursivly', function () {
     var data = fixture();
-    applyFilterToKey(data, 'authorization', 'remove');
+    data = applyFilterToKey(data, 'authorization', 'remove');
     expect(data).to.eql({
       req: { headers: {} }
     });
@@ -23,7 +24,7 @@ describe('applyFilterToKey(obj, key, action)', function () {
 
   it('should remove an entire branch', function () {
     var data = fixture();
-    applyFilterToKey(data, 'headers', 'remove');
+    data = applyFilterToKey(data, 'headers', 'remove');
     expect(data).to.eql({
       req: { }
     });
@@ -31,7 +32,7 @@ describe('applyFilterToKey(obj, key, action)', function () {
 
   it('should remove an entire branch with censor', function () {
     var data = fixture();
-    applyFilterToKey(data, 'headers', 'censor');
+    data = applyFilterToKey(data, 'headers', 'censor');
     expect(data).to.eql({
       req: { }
     });
@@ -39,7 +40,7 @@ describe('applyFilterToKey(obj, key, action)', function () {
 
   it('should censor a key in an object recursivly', function () {
     var data = fixture();
-    applyFilterToKey(data, 'authorization', 'censor');
+    data = applyFilterToKey(data, 'authorization', 'censor');
     expect(data).to.eql({
       req: {
         headers: {
@@ -52,7 +53,7 @@ describe('applyFilterToKey(obj, key, action)', function () {
   it('should censor key with a RegEx in an object recursivly', function () {
     var data = fixture();
     var regex = '/([^\\s]+)$/';
-    applyFilterToKey(data, 'authorization', regex);
+    data = applyFilterToKey(data, 'authorization', regex);
     expect(data).to.eql({
       req: {
         headers: {
@@ -62,4 +63,44 @@ describe('applyFilterToKey(obj, key, action)', function () {
     });
   });
 
+  it('uses the JSON version of objects for serializaion', function () {
+    var data = applyFilterToKey({
+      a: {
+        b: 1,
+        toJSON: () => ({ c: 10 })
+      }
+    }, 'c', 'censor');
+
+    expect(data).to.eql({
+      a: {
+        c: 'XX'
+      }
+    });
+  });
+
+  describe('applyFiltersToKeys(obj, actionsByKey)', function () {
+    it('applies applyFilterToKey() for each key+prop in actionsByKey', function () {
+      var data = applyFiltersToKeys({
+        a: {
+          b: {
+            c: 1
+          },
+          d: {
+            e: 'foobar'
+          }
+        }
+      }, {
+        b: 'remove',
+        e: 'censor',
+      });
+
+      expect(data).to.eql({
+        a: {
+          d: {
+            e: 'XXXXXX',
+          },
+        },
+      });
+    });
+  });
 });

--- a/src/server/logging/applyFilterToKey.js
+++ b/src/server/logging/applyFilterToKey.js
@@ -1,8 +1,12 @@
+function toPojo(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
 function replacer(match, group) {
   return (new Array(group.length + 1).join('X'));
 }
 
-module.exports = function applyFilterToKey(obj, key, action) {
+function apply(obj, key, action) {
   for (let k in obj)  {
     if (obj.hasOwnProperty(k)) {
       let val = obj[k];
@@ -24,8 +28,19 @@ module.exports = function applyFilterToKey(obj, key, action) {
           }
         }
       } else if (typeof val === 'object') {
-        applyFilterToKey(val, key, action);
+        val = apply(val, key, action);
       }
     }
   }
+  return obj;
+}
+
+module.exports = function applyFilterToKey(obj, key, action) {
+  return apply(toPojo(obj), key, action);
+};
+
+module.exports.applyFiltersToKeys = function (obj, actionsByKey) {
+  return Object.keys(actionsByKey).reduce((output, key) => {
+    return apply(output, key, actionsByKey[key]);
+  }, toPojo(obj));
 };


### PR DESCRIPTION
`applyFilterToKey()` used to choke on circular structures by simply recursing through the object passed in. When we create a circular structure though, we generally provide a simplified version of the object via `obj#toJSON()`. This makes logging those objects simple, and now the filter will use the same mechanism before attempting to itterate the object.
