### PR TITLE
[Infra UI] Improve ECS apache and nginx formatting rules and restore pre-ECS rules

### DIFF
--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_apache2.test.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_apache2.test.ts
@@ -8,102 +8,243 @@ import { compileFormattingRules } from '../message';
 import { filebeatApache2Rules } from './filebeat_apache2';
 
 const { format } = compileFormattingRules(filebeatApache2Rules);
+
 describe('Filebeat Rules', () => {
-  test('Apache2 Access', () => {
-    const event = {
-      'apache2.access': true,
-      'source.ip': '192.168.1.42',
-      'user.name': 'admin',
-      'http.request.method': 'GET',
-      'url.original': '/faqs',
-      'http.version': '1.1',
-      'http.response.status_code': '200',
-      'apache2.access.body_sent.bytes': 1024,
-    };
-    const message = format(event);
-    expect(message).toEqual([
-      {
-        constant: '[Apache][access] ',
-      },
-      {
-        field: 'source.ip',
-        highlights: [],
-        value: '192.168.1.42',
-      },
-      {
-        constant: ' ',
-      },
-      {
-        field: 'user.name',
-        highlights: [],
-        value: 'admin',
-      },
-      {
-        constant: ' "',
-      },
-      {
-        field: 'http.request.method',
-        highlights: [],
-        value: 'GET',
-      },
-      {
-        constant: ' ',
-      },
-      {
-        field: 'url.original',
-        highlights: [],
-        value: '/faqs',
-      },
-      {
-        constant: ' HTTP/',
-      },
-      {
-        field: 'http.version',
-        highlights: [],
-        value: '1.1',
-      },
-      {
-        constant: '" ',
-      },
-      {
-        field: 'http.response.status_code',
-        highlights: [],
-        value: '200',
-      },
-      {
-        constant: ' ',
-      },
-      {
-        field: 'apache2.access.body_sent.bytes',
-        highlights: [],
-        value: '1024',
-      },
-    ]);
+  describe('in ECS format', () => {
+    test('Apache2 Access', () => {
+      const flattenedDocument = {
+        '@timestamp': '2016-12-26T16:22:13.000Z',
+        'ecs.version': '1.0.0-beta2',
+        'event.dataset': 'apache.access',
+        'event.module': 'apache',
+        'fileset.name': 'access',
+        'http.request.method': 'GET',
+        'http.request.referrer': '-',
+        'http.response.body.bytes': 499,
+        'http.response.status_code': 404,
+        'http.version': '1.1',
+        'input.type': 'log',
+        'log.offset': 73,
+        'service.type': 'apache',
+        'source.address': '192.168.33.1',
+        'source.ip': '192.168.33.1',
+        'url.original': '/hello',
+        'user.name': '-',
+        'user_agent.device': 'Other',
+        'user_agent.major': '50',
+        'user_agent.minor': '0',
+        'user_agent.name': 'Firefox',
+        'user_agent.original':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0',
+        'user_agent.os.full_name': 'Mac OS X 10.12',
+        'user_agent.os.major': '10',
+        'user_agent.os.minor': '12',
+        'user_agent.os.name': 'Mac OS X',
+      };
+
+      expect(format(flattenedDocument)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "constant": "[Apache][access] ",
+  },
+  Object {
+    "field": "source.ip",
+    "highlights": Array [],
+    "value": "192.168.33.1",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "user.name",
+    "highlights": Array [],
+    "value": "-",
+  },
+  Object {
+    "constant": " \\"",
+  },
+  Object {
+    "field": "http.request.method",
+    "highlights": Array [],
+    "value": "GET",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "url.original",
+    "highlights": Array [],
+    "value": "/hello",
+  },
+  Object {
+    "constant": " HTTP/",
+  },
+  Object {
+    "field": "http.version",
+    "highlights": Array [],
+    "value": "1.1",
+  },
+  Object {
+    "constant": "\\" ",
+  },
+  Object {
+    "field": "http.response.status_code",
+    "highlights": Array [],
+    "value": "404",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "http.response.body.bytes",
+    "highlights": Array [],
+    "value": "499",
+  },
+]
+`);
+    });
+
+    test('Apache2 Error', () => {
+      const flattenedDocument = {
+        '@timestamp': '2016-12-26T16:22:08.000Z',
+        'ecs.version': '1.0.0-beta2',
+        'event.dataset': 'apache.error',
+        'event.module': 'apache',
+        'fileset.name': 'error',
+        'input.type': 'log',
+        'log.level': 'error',
+        'log.offset': 0,
+        message: 'File does not exist: /var/www/favicon.ico',
+        'service.type': 'apache',
+        'source.address': '192.168.33.1',
+        'source.ip': '192.168.33.1',
+      };
+
+      expect(format(flattenedDocument)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "constant": "[Apache][",
+  },
+  Object {
+    "field": "log.level",
+    "highlights": Array [],
+    "value": "error",
+  },
+  Object {
+    "constant": "] ",
+  },
+  Object {
+    "field": "message",
+    "highlights": Array [],
+    "value": "File does not exist: /var/www/favicon.ico",
+  },
+]
+`);
+    });
   });
-  test('Apache2 Error', () => {
-    const event = {
-      'apache2.error.message':
-        'AH00489: Apache/2.4.18 (Ubuntu) configured -- resuming normal operations',
-      'apache2.error.level': 'notice',
-    };
-    const message = format(event);
-    expect(message).toEqual([
-      {
-        constant: '[Apache][',
-      },
-      {
-        field: 'apache2.error.level',
-        highlights: [],
-        value: 'notice',
-      },
-      {
-        constant: '] ',
-      },
-      {
-        field: 'apache2.error.message',
-        highlights: [],
-        value: 'AH00489: Apache/2.4.18 (Ubuntu) configured -- resuming normal operations',
-      },
-    ]);
+
+  describe('in pre-ECS format', () => {
+    test('Apache2 Access', () => {
+      const flattenedDocument = {
+        'apache2.access': true,
+        'apache2.access.remote_ip': '192.168.1.42',
+        'apache2.access.user_name': 'admin',
+        'apache2.access.method': 'GET',
+        'apache2.access.url': '/faqs',
+        'apache2.access.http_version': '1.1',
+        'apache2.access.response_code': '200',
+        'apache2.access.body_sent.bytes': 1024,
+      };
+
+      expect(format(flattenedDocument)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "constant": "[Apache][access] ",
+  },
+  Object {
+    "field": "apache2.access.remote_ip",
+    "highlights": Array [],
+    "value": "192.168.1.42",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "apache2.access.user_name",
+    "highlights": Array [],
+    "value": "admin",
+  },
+  Object {
+    "constant": " \\"",
+  },
+  Object {
+    "field": "apache2.access.method",
+    "highlights": Array [],
+    "value": "GET",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "apache2.access.url",
+    "highlights": Array [],
+    "value": "/faqs",
+  },
+  Object {
+    "constant": " HTTP/",
+  },
+  Object {
+    "field": "apache2.access.http_version",
+    "highlights": Array [],
+    "value": "1.1",
+  },
+  Object {
+    "constant": "\\" ",
+  },
+  Object {
+    "field": "apache2.access.response_code",
+    "highlights": Array [],
+    "value": "200",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "apache2.access.body_sent.bytes",
+    "highlights": Array [],
+    "value": "1024",
+  },
+]
+`);
+    });
+
+    test('Apache2 Error', () => {
+      const flattenedDocument = {
+        'apache2.error.message':
+          'AH00489: Apache/2.4.18 (Ubuntu) configured -- resuming normal operations',
+        'apache2.error.level': 'notice',
+      };
+
+      expect(format(flattenedDocument)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "constant": "[Apache][",
+  },
+  Object {
+    "field": "apache2.error.level",
+    "highlights": Array [],
+    "value": "notice",
+  },
+  Object {
+    "constant": "] ",
+  },
+  Object {
+    "field": "apache2.error.message",
+    "highlights": Array [],
+    "value": "AH00489: Apache/2.4.18 (Ubuntu) configured -- resuming normal operations",
+  },
+]
+`);
+    });
   });
 });

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_apache2.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_apache2.ts
@@ -6,8 +6,11 @@
 
 export const filebeatApache2Rules = [
   {
+    // ECS
     when: {
-      exists: ['apache2.access'],
+      values: {
+        'event.dataset': 'apache.access',
+      },
     },
     format: [
       {
@@ -50,11 +53,84 @@ export const filebeatApache2Rules = [
         constant: ' ',
       },
       {
+        field: 'http.response.body.bytes',
+      },
+    ],
+  },
+  {
+    // pre-ECS
+    when: {
+      exists: ['apache2.access'],
+    },
+    format: [
+      {
+        constant: '[Apache][access] ',
+      },
+      {
+        field: 'apache2.access.remote_ip',
+      },
+      {
+        constant: ' ',
+      },
+      {
+        field: 'apache2.access.user_name',
+      },
+      {
+        constant: ' "',
+      },
+      {
+        field: 'apache2.access.method',
+      },
+      {
+        constant: ' ',
+      },
+      {
+        field: 'apache2.access.url',
+      },
+      {
+        constant: ' HTTP/',
+      },
+      {
+        field: 'apache2.access.http_version',
+      },
+      {
+        constant: '" ',
+      },
+      {
+        field: 'apache2.access.response_code',
+      },
+      {
+        constant: ' ',
+      },
+      {
         field: 'apache2.access.body_sent.bytes',
       },
     ],
   },
   {
+    // ECS
+    when: {
+      values: {
+        'event.dataset': 'apache.error',
+      },
+    },
+    format: [
+      {
+        constant: '[Apache][',
+      },
+      {
+        field: 'log.level',
+      },
+      {
+        constant: '] ',
+      },
+      {
+        field: 'message',
+      },
+    ],
+  },
+  {
+    // pre-ECS
     when: {
       exists: ['apache2.error.message'],
     },

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.test.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.test.ts
@@ -8,106 +8,249 @@ import { compileFormattingRules } from '../message';
 import { filebeatNginxRules } from './filebeat_nginx';
 
 const { format } = compileFormattingRules(filebeatNginxRules);
+
 describe('Filebeat Rules', () => {
-  test('Nginx Access Rule', () => {
-    const event = {
-      'nginx.access': true,
-      'source.ip': '192.168.1.42',
-      'user.name': 'admin',
-      'http.request.method': 'GET',
-      'url.original': '/faq',
-      'http.version': '1.1',
-      'nginx.access.body_sent.bytes': 1024,
-      'http.response.status_code': 200,
-    };
-    const message = format(event);
-    expect(message).toEqual([
-      {
-        constant: '[Nginx][access] ',
-      },
-      {
-        field: 'source.ip',
-        highlights: [],
-        value: '192.168.1.42',
-      },
-      {
-        constant: ' ',
-      },
-      {
-        field: 'user.name',
-        highlights: [],
-        value: 'admin',
-      },
-      {
-        constant: ' "',
-      },
-      {
-        field: 'http.request.method',
-        highlights: [],
-        value: 'GET',
-      },
-      {
-        constant: ' ',
-      },
-      {
-        field: 'url.original',
-        highlights: [],
-        value: '/faq',
-      },
-      {
-        constant: ' HTTP/',
-      },
-      {
-        field: 'http.version',
-        highlights: [],
-        value: '1.1',
-      },
-      {
-        constant: '" ',
-      },
-      {
-        field: 'http.response.status_code',
-        highlights: [],
-        value: '200',
-      },
-      {
-        constant: ' ',
-      },
-      {
-        field: 'nginx.access.body_sent.bytes',
-        highlights: [],
-        value: '1024',
-      },
-    ]);
+  describe('in ECS format', () => {
+    test('Nginx Access', () => {
+      const flattenedDocument = {
+        '@timestamp': '2017-05-29T19:02:48.000Z',
+        'ecs.version': '1.0.0-beta2',
+        'event.dataset': 'nginx.access',
+        'event.module': 'nginx',
+        'fileset.name': 'access',
+        'http.request.method': 'GET',
+        'http.request.referrer': '-',
+        'http.response.body.bytes': 612,
+        'http.response.status_code': 404,
+        'http.version': '1.1',
+        'input.type': 'log',
+        'log.offset': 183,
+        'service.type': 'nginx',
+        'source.ip': '172.17.0.1',
+        'url.original': '/stringpatch',
+        'user.name': '-',
+        'user_agent.device': 'Other',
+        'user_agent.major': '15',
+        'user_agent.minor': '0',
+        'user_agent.name': 'Firefox Alpha',
+        'user_agent.original':
+          'Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2',
+        'user_agent.os.full_name': 'Windows 7',
+        'user_agent.os.name': 'Windows 7',
+        'user_agent.patch': 'a2',
+      };
+
+      expect(format(flattenedDocument)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "constant": "[Nginx][access] ",
+  },
+  Object {
+    "field": "source.ip",
+    "highlights": Array [],
+    "value": "172.17.0.1",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "user.name",
+    "highlights": Array [],
+    "value": "-",
+  },
+  Object {
+    "constant": " \\"",
+  },
+  Object {
+    "field": "http.request.method",
+    "highlights": Array [],
+    "value": "GET",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "url.original",
+    "highlights": Array [],
+    "value": "/stringpatch",
+  },
+  Object {
+    "constant": " HTTP/",
+  },
+  Object {
+    "field": "http.version",
+    "highlights": Array [],
+    "value": "1.1",
+  },
+  Object {
+    "constant": "\\" ",
+  },
+  Object {
+    "field": "http.response.status_code",
+    "highlights": Array [],
+    "value": "404",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "http.response.body.bytes",
+    "highlights": Array [],
+    "value": "612",
+  },
+]
+`);
+    });
+
+    test('Nginx Error', () => {
+      const flattenedDocument = {
+        '@timestamp': '2016-10-25T14:49:34.000Z',
+        'ecs.version': '1.0.0-beta2',
+        'event.dataset': 'nginx.error',
+        'event.module': 'nginx',
+        'fileset.name': 'error',
+        'input.type': 'log',
+        'log.level': 'error',
+        'log.offset': 0,
+        message:
+          'open() "/usr/local/Cellar/nginx/1.10.2_1/html/favicon.ico" failed (2: No such file or directory), client: 127.0.0.1, server: localhost, request: "GET /favicon.ico HTTP/1.1", host: "localhost:8080", referrer: "http://localhost:8080/"',
+        'nginx.error.connection_id': 1,
+        'process.pid': 54053,
+        'process.thread.id': 0,
+        'service.type': 'nginx',
+      };
+
+      expect(format(flattenedDocument)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "constant": "[Nginx]",
+  },
+  Object {
+    "constant": "[",
+  },
+  Object {
+    "field": "log.level",
+    "highlights": Array [],
+    "value": "error",
+  },
+  Object {
+    "constant": "] ",
+  },
+  Object {
+    "field": "message",
+    "highlights": Array [],
+    "value": "open() \\"/usr/local/Cellar/nginx/1.10.2_1/html/favicon.ico\\" failed (2: No such file or directory), client: 127.0.0.1, server: localhost, request: \\"GET /favicon.ico HTTP/1.1\\", host: \\"localhost:8080\\", referrer: \\"http://localhost:8080/\\"",
+  },
+]
+`);
+    });
   });
-  test('Nginx Access Rule', () => {
-    const event = {
-      'nginx.error.message':
-        'connect() failed (111: Connection refused) while connecting to upstream, client: 127.0.0.1, server: localhost, request: "GET /php-status?json= HTTP/1.1", upstream: "fastcgi://[::1]:9000", host: "localhost"',
-      'nginx.error.level': 'error',
-    };
-    const message = format(event);
-    expect(message).toEqual([
-      {
-        constant: '[Nginx]',
-      },
-      {
-        constant: '[',
-      },
-      {
-        field: 'nginx.error.level',
-        highlights: [],
-        value: 'error',
-      },
-      {
-        constant: '] ',
-      },
-      {
-        field: 'nginx.error.message',
-        highlights: [],
-        value:
+
+  describe('in pre-ECS format', () => {
+    test('Nginx Access', () => {
+      const flattenedDocument = {
+        'nginx.access': true,
+        'nginx.access.remote_ip': '192.168.1.42',
+        'nginx.access.user_name': 'admin',
+        'nginx.access.method': 'GET',
+        'nginx.access.url': '/faq',
+        'nginx.access.http_version': '1.1',
+        'nginx.access.body_sent.bytes': 1024,
+        'nginx.access.response_code': 200,
+      };
+
+      expect(format(flattenedDocument)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "constant": "[Nginx][access] ",
+  },
+  Object {
+    "field": "nginx.access.remote_ip",
+    "highlights": Array [],
+    "value": "192.168.1.42",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "nginx.access.user_name",
+    "highlights": Array [],
+    "value": "admin",
+  },
+  Object {
+    "constant": " \\"",
+  },
+  Object {
+    "field": "nginx.access.method",
+    "highlights": Array [],
+    "value": "GET",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "nginx.access.url",
+    "highlights": Array [],
+    "value": "/faq",
+  },
+  Object {
+    "constant": " HTTP/",
+  },
+  Object {
+    "field": "nginx.access.http_version",
+    "highlights": Array [],
+    "value": "1.1",
+  },
+  Object {
+    "constant": "\\" ",
+  },
+  Object {
+    "field": "nginx.access.response_code",
+    "highlights": Array [],
+    "value": "200",
+  },
+  Object {
+    "constant": " ",
+  },
+  Object {
+    "field": "nginx.access.body_sent.bytes",
+    "highlights": Array [],
+    "value": "1024",
+  },
+]
+`);
+    });
+
+    test('Nginx Error', () => {
+      const flattenedDocument = {
+        'nginx.error.message':
           'connect() failed (111: Connection refused) while connecting to upstream, client: 127.0.0.1, server: localhost, request: "GET /php-status?json= HTTP/1.1", upstream: "fastcgi://[::1]:9000", host: "localhost"',
-      },
-    ]);
+        'nginx.error.level': 'error',
+      };
+
+      expect(format(flattenedDocument)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "constant": "[Nginx]",
+  },
+  Object {
+    "constant": "[",
+  },
+  Object {
+    "field": "nginx.error.level",
+    "highlights": Array [],
+    "value": "error",
+  },
+  Object {
+    "constant": "] ",
+  },
+  Object {
+    "field": "nginx.error.message",
+    "highlights": Array [],
+    "value": "connect() failed (111: Connection refused) while connecting to upstream, client: 127.0.0.1, server: localhost, request: \\"GET /php-status?json= HTTP/1.1\\", upstream: \\"fastcgi://[::1]:9000\\", host: \\"localhost\\"",
+  },
+]
+`);
+    });
   });
 });

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.ts
@@ -6,8 +6,11 @@
 
 export const filebeatNginxRules = [
   {
+    // ECS
     when: {
-      exists: ['nginx.access'],
+      values: {
+        'event.dataset': 'nginx.access',
+      },
     },
     format: [
       {
@@ -50,11 +53,87 @@ export const filebeatNginxRules = [
         constant: ' ',
       },
       {
+        field: 'http.response.body.bytes',
+      },
+    ],
+  },
+  {
+    // pre-ECS
+    when: {
+      exists: ['nginx.access'],
+    },
+    format: [
+      {
+        constant: '[Nginx][access] ',
+      },
+      {
+        field: 'nginx.access.remote_ip',
+      },
+      {
+        constant: ' ',
+      },
+      {
+        field: 'nginx.access.user_name',
+      },
+      {
+        constant: ' "',
+      },
+      {
+        field: 'nginx.access.method',
+      },
+      {
+        constant: ' ',
+      },
+      {
+        field: 'nginx.access.url',
+      },
+      {
+        constant: ' HTTP/',
+      },
+      {
+        field: 'nginx.access.http_version',
+      },
+      {
+        constant: '" ',
+      },
+      {
+        field: 'nginx.access.response_code',
+      },
+      {
+        constant: ' ',
+      },
+      {
         field: 'nginx.access.body_sent.bytes',
       },
     ],
   },
   {
+    // ECS
+    when: {
+      values: {
+        'event.dataset': 'nginx.error',
+      },
+    },
+    format: [
+      {
+        constant: '[Nginx]',
+      },
+      {
+        constant: '[',
+      },
+      {
+        field: 'log.level',
+      },
+      {
+        constant: '] ',
+      },
+      {
+        field: 'message',
+      },
+    ],
+  },
+  {
+    // pre-ECS
     when: {
       exists: ['nginx.error.message'],
     },


### PR DESCRIPTION
This restores the pre-ECS log formatting rules alongside the new ECS ones and fixes a few incorrect fields. The tests are enhanced to use upstream filebeat test data for the new ECS format while retaining the pre-ECS tests. They are also refactored to use the inline snapshot capabilities of jest for easier future maintenance.